### PR TITLE
Coroutine store

### DIFF
--- a/tka/build.gradle
+++ b/tka/build.gradle
@@ -11,6 +11,11 @@ dependencies {
     implementation libraries.kotlin.jdk
     implementation libraries.rx.java
 
+    // Core Coroutines
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0"
+    // Android-specific Coroutines
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0"
+
     testImplementation libraries.junit
 }
 

--- a/tka/src/main/kotlin/com/xm/tka/Effect.kt
+++ b/tka/src/main/kotlin/com/xm/tka/Effect.kt
@@ -11,6 +11,9 @@ import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.core.Single
 import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.subjects.PublishSubject
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flowOf
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedDeque
 import java.util.concurrent.locks.ReentrantLock
@@ -32,6 +35,7 @@ import kotlin.concurrent.withLock
  * Source: https://github.com/pointfreeco/swift-composable-architecture/blob/main/Sources/ComposableArchitecture/Effect.swift
  */
 typealias Effect<ACTION> = Observable<ACTION>
+typealias FlowEffect<ACTION> = Flow<ACTION>
 
 /**
  * [Effect] utility functions
@@ -44,12 +48,16 @@ object Effects {
      */
     fun <ACTION : Any> none(): Effect<ACTION> = Observable.empty()
 
+    fun <ACTION : Any> flowNone(): FlowEffect<ACTION> = emptyFlow()
+
     /**
      * Initializes an effect that immediately emits the value passed in.
      *
      * @param action: The action that is immediately emitted by the effect.
      */
     fun <ACTION : Any> just(action: ACTION): Effect<ACTION> = Observable.just(action)
+
+    fun <ACTION : Any> justFlow(action: ACTION): FlowEffect<ACTION> = flowOf(action)
 
     /**
      * Initializes an effect that immediately fails with the error passed in.
@@ -85,6 +93,9 @@ object Effects {
      */
     fun <ACTION : Any> merge(vararg effects: Effect<ACTION>): Effect<ACTION> =
         Observable.merge(effects.toList())
+
+    fun <ACTION : Any> merge(vararg effects: FlowEffect<ACTION>): FlowEffect<ACTION> =
+        kotlinx.coroutines.flow.merge(*effects)
 
     /**
      * Concatenates a variadic list of effects together into a single effect, which runs the effects
@@ -125,6 +136,8 @@ object Effects {
  * Turns any [Flowable] into an `Effect`
  */
 fun <ACTION : Any> Flowable<ACTION>.toEffect(): Effect<ACTION> = this.toObservable()
+
+fun <ACTION : Any> Flow<ACTION>.toEffect(): FlowEffect<ACTION> = this
 
 /**
  * Turns any [Single] into an `Effect`

--- a/tka/src/main/kotlin/com/xm/tka/coroutine/CoroutineStore.kt
+++ b/tka/src/main/kotlin/com/xm/tka/coroutine/CoroutineStore.kt
@@ -1,0 +1,58 @@
+package com.xm.tka.coroutine
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class CoroutineStore<STATE : Any, ACTION : Any> private constructor(
+    val sendAction: (ACTION) -> Unit,
+    val state: Flow<STATE> = emptyFlow()
+) {
+    
+    fun send(action: ACTION) = sendAction(action)
+
+    fun <LOCAL_STATE : Any, LOCAL_ACTION : Any> view(
+        mapToLocalState: (STATE) -> LOCAL_STATE,
+        mapToGlobalAction: (LOCAL_ACTION) -> ACTION,
+    ): CoroutineStore<LOCAL_STATE, LOCAL_ACTION> = CoroutineStore(
+        state = state.map { mapToLocalState(it) }.distinctUntilChanged(),
+        sendAction = { action ->
+            sendAction(mapToGlobalAction(action))
+        },
+    )
+
+    companion object {
+        fun <STATE : Any, ACTION : Any> create(
+            initialState: STATE,
+            reducer: (STATE, ACTION) -> FlowReduced<STATE, ACTION>,
+            storeScopeProvider: StoreScopeProvider,
+            dispatcherProvider: DispatcherProvider,
+        ): CoroutineStore<STATE, ACTION> {
+            val storeScope = storeScopeProvider.getStoreScope()
+            val state = MutableStateFlow(initialState)
+            lateinit var sendAction: (ACTION) -> Unit
+            sendAction = { action: ACTION ->
+                storeScope.launch(context = dispatcherProvider.main) {
+                    val (nextState, effect) = reducer(initialState, action)
+                    state.update { nextState }
+                    effect.collectLatest {
+                        sendAction(it)
+                    }
+                }
+            }
+
+            return CoroutineStore(
+                sendAction = sendAction,
+                state = state
+            )
+        }
+
+    }
+
+
+}

--- a/tka/src/main/kotlin/com/xm/tka/coroutine/CoroutineStore.kt
+++ b/tka/src/main/kotlin/com/xm/tka/coroutine/CoroutineStore.kt
@@ -16,29 +16,31 @@ class CoroutineStore<STATE : Any, ACTION : Any> private constructor(
     
     fun send(action: ACTION) = sendAction(action)
 
-    fun <LOCAL_STATE : Any, LOCAL_ACTION : Any> view(
-        mapToLocalState: (STATE) -> LOCAL_STATE,
-        mapToGlobalAction: (LOCAL_ACTION) -> ACTION,
+    fun <LOCAL_STATE : Any, LOCAL_ACTION : Any> scope(
+        toLocalState: (STATE) -> LOCAL_STATE,
+        fromLocalAction: (LOCAL_ACTION) -> ACTION,
     ): CoroutineStore<LOCAL_STATE, LOCAL_ACTION> = CoroutineStore(
-        state = state.map { mapToLocalState(it) }.distinctUntilChanged(),
+        state = state.map { toLocalState(it) }.distinctUntilChanged(),
         sendAction = { action ->
-            sendAction(mapToGlobalAction(action))
+            sendAction(fromLocalAction(action))
         },
     )
 
     companion object {
-        fun <STATE : Any, ACTION : Any> create(
+        fun <STATE : Any, ACTION : Any, ENVIRONMENT : Any> create(
             initialState: STATE,
-            reducer: (STATE, ACTION) -> FlowReduced<STATE, ACTION>,
+            reducer: FlowReducer<STATE, ACTION, ENVIRONMENT>,
+            environment: ENVIRONMENT,
             storeScopeProvider: StoreScopeProvider,
             dispatcherProvider: DispatcherProvider,
         ): CoroutineStore<STATE, ACTION> {
             val storeScope = storeScopeProvider.getStoreScope()
             val state = MutableStateFlow(initialState)
+
             lateinit var sendAction: (ACTION) -> Unit
             sendAction = { action: ACTION ->
                 storeScope.launch(context = dispatcherProvider.main) {
-                    val (nextState, effect) = reducer(initialState, action)
+                    val (nextState, effect) = reducer.reduce(state.value, action, environment)
                     state.update { nextState }
                     effect.collectLatest {
                         sendAction(it)

--- a/tka/src/main/kotlin/com/xm/tka/coroutine/DispatcherProvider.kt
+++ b/tka/src/main/kotlin/com/xm/tka/coroutine/DispatcherProvider.kt
@@ -1,0 +1,9 @@
+package com.xm.tka.coroutine
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+data class DispatcherProvider(
+    val io: CoroutineDispatcher,
+    val computation: CoroutineDispatcher,
+    val main: CoroutineDispatcher,
+)

--- a/tka/src/main/kotlin/com/xm/tka/coroutine/FlowReducer.kt
+++ b/tka/src/main/kotlin/com/xm/tka/coroutine/FlowReducer.kt
@@ -1,0 +1,293 @@
+@file:Suppress("unused", "MemberVisibilityCanBePrivate")
+
+package com.xm.tka.coroutine
+
+import com.xm.tka.ActionPrism
+import com.xm.tka.Effects.flowNone
+import com.xm.tka.Effects.merge
+import com.xm.tka.StateLens
+import com.xm.tka.FlowEffect
+import com.xm.tka.Getter
+import com.xm.tka.coroutine.FlowReducer.Companion.combine
+import kotlinx.coroutines.flow.map
+
+
+/**
+ * A reducer describes how to evolve the current state of an application to the next state, given
+ * an action, and describes what `Effect`s should be executed later by the store, if any.
+ *
+ * Reducers have 3 generics:
+ * * [STATE]: A type that holds the current state of the application
+ * * [ACTION]: A type that holds all possible actions that cause the state of the application to
+ *   change.
+ * * [ENVIRONMENT]: A type that holds all dependencies needed in order to produce `Effect`s, such
+ *   as API clients, analytics clients, random number generators, etc.
+ *
+ * - Note: The thread on which effects output is important. An effect's output is immediately sent
+ * back into the store, and `Store` is not thread safe. This means all effects must receive
+ * values on the same thread, **and** if the `Store` is being used to drive UI then all output
+ * must be on the main thread. You can use the `Publisher` method `receive(on:)` for make the
+ * effect output its values on the thread of your choice.
+ *
+ * Source: https://github.com/pointfreeco/swift-composable-architecture/blob/main/Sources/ComposableArchitecture/Reducer.swift
+ */
+interface FlowReducer<STATE, ACTION : Any, ENVIRONMENT> {
+
+    fun reduce(state: STATE, action: ACTION, environment: ENVIRONMENT): FlowReduced<STATE, ACTION>
+
+    /**
+     * Transforms a reducer that works on local state, action and environment into one that works on
+     * global state, action and environment. It accomplishes this by providing 3 transformations to
+     * the method:
+     *
+     * * A [StateLens] that can get/set a piece of local state from the global state.
+     * * An [ActionPrism] that can extract/embed a local action into a global action.
+     * * A [Getter] that can transform the global environment into a local environment.
+     *
+     * This operation is important for breaking down large reducers into small ones. When used with
+     * the `combine` operator you can define many reducers that work on small pieces of domain, and
+     * then _pull them back_ and _combine_ them into one big reducer that works on a large domain.
+     *
+     * @param toLocalState: A [StateLens] that can get/set [STATE] inside [GLOBAL_STATE].
+     * @param toLocalAction: An [ActionPrism] that can extract/embed [ACTION] from GLOBAL_ACTION.
+     * @param toLocalEnvironment: A [Getter] that transforms [GLOBAL_ENVIRONMENT] into [ENVIRONMENT].
+     */
+    fun <GLOBAL_STATE, GLOBAL_ACTION : Any, GLOBAL_ENVIRONMENT> pullback(
+        toLocalState: StateLens<GLOBAL_STATE, STATE>,
+        toLocalAction: ActionPrism<GLOBAL_ACTION, ACTION>,
+        toLocalEnvironment: Getter<GLOBAL_ENVIRONMENT, ENVIRONMENT>
+    ): FlowReducer<GLOBAL_STATE, GLOBAL_ACTION, GLOBAL_ENVIRONMENT> =
+        FlowReducer { state, action, environment ->
+            // convert to global action to local action
+            toLocalAction.get(action)
+                // map global state to local state and reduce it
+                ?.let { localAction ->
+                    reduce(
+                        toLocalState.get(state),
+                        localAction,
+                        toLocalEnvironment(environment)
+                    )
+                }
+                // update global state with the new local state and return the updated state
+                ?.let { (localState, localEffect) ->
+                    // map local effect to global effect
+                    localEffect
+                        .map { localAction -> toLocalAction.reverseGet(localAction) }
+                        // return the update global state along with the global actions
+                        .let { effect -> toLocalState.set(state, localState) + effect }
+                }
+                ?: (state + flowNone())
+        }
+
+    /**
+     * Transforms a reducer that works on local state, action and environment into one that works on
+     * global state and action (without the need of an environment). It accomplishes this by providing
+     * 2 transformations to the method:
+     *
+     * * A [StateLens] that can get/set a piece of local state from the global state.
+     * * An [ActionPrism] that can extract/embed a local action into a global action.
+     *
+     * This operation is important for breaking down large reducers into small ones. When used with
+     * the `combine` operator you can define many reducers that work on small pieces of domain, and
+     * then _pull them back_ and _combine_ them into one big reducer that works on a large domain.
+     *
+     * @param toLocalState: A [StateLens] that can get/set [STATE] inside [GLOBAL_STATE].
+     * @param toLocalAction: An [ActionPrism] that can extract/embed [ACTION] from GLOBAL_ACTION.
+     */
+    fun <STATE, ACTION : Any, GLOBAL_STATE, GLOBAL_ACTION : Any> FlowReducer<STATE, ACTION, Unit>.pullback(
+        toLocalState: StateLens<GLOBAL_STATE, STATE>,
+        toLocalAction: ActionPrism<GLOBAL_ACTION, ACTION>
+    ): FlowReducer<GLOBAL_STATE, GLOBAL_ACTION, Unit> = pullback(toLocalState, toLocalAction) { }
+
+    companion object {
+
+        /**
+         * Initializes a reducer from a simple reducer function signature.
+         *
+         * @param reduce : A function signature that takes state, action and environment.
+         */
+        operator fun <STATE, ACTION : Any, ENVIRONMENT> invoke(
+            reduce: FlowReduce<STATE, ACTION, ENVIRONMENT>
+        ): FlowReducer<STATE, ACTION, ENVIRONMENT> =
+            object : FlowReducer<STATE, ACTION, ENVIRONMENT> {
+
+                private val context: FlowReduceContext<STATE, ACTION> = FlowReduceContext()
+
+                override fun reduce(
+                    state: STATE,
+                    action: ACTION,
+                    environment: ENVIRONMENT
+                ): FlowReduced<STATE, ACTION> = reduce(context, state, action, environment)
+            }
+
+        /**
+         * A reducer that performs no state mutations and returns no effects.
+         */
+        fun <STATE, ACTION : Any, ENVIRONMENT> empty(): FlowReducer<STATE, ACTION, ENVIRONMENT> =
+            FlowReducer { state, _, _ -> state + flowNone() }
+
+        /**
+         * Combines many reducers into a single one by running each one on the state, and merging
+         * all of the effects.
+         *
+         * It is important to note that the order of combining reducers matter. Combining `reducerA` with
+         * `reducerB` is not necessarily the same as combining `reducerB` with `reducerA`.
+         *
+         * This can become an issue when working with reducers that have overlapping domains. For
+         * example, if `reducerA` embeds the domain of `reducerB` and reacts to its actions or modifies
+         * its state, it can make a difference if `reducerA` chooses to modify `reducerB`'s state
+         * _before_ or _after_ `reducerB` runs.
+         *
+         *  This is perhaps most easily seen when working with `optional` reducers, where the parent
+         *  domain may listen to the child domain and `null` out its state. If the parent reducer runs
+         *  before the child reducer, then the child reducer will not be able to react to its own action.
+         *
+         *  Similar can be said for a `forEach` reducer. If the parent domain modifies the child
+         *  collection by moving, removing, or modifying an element before the `forEach` reducer runs, the
+         *  `forEach` reducer may perform its action against the wrong element, an element that no longer
+         *  exists, or an element in an unexpected state.
+         *
+         *  Running a parent reducer before a child reducer can be considered an application logic
+         *  error, and can produce assertion failures. So you should almost always combine reducers in
+         *  order from child to parent domain.
+         *
+         * @param reducers: A list of reducers.
+         * @return A single [FlowReducer].
+         */
+        fun <STATE, ACTION : Any, ENVIRONMENT> combine(
+            reducers: List<FlowReducer<STATE, ACTION, ENVIRONMENT>>
+        ): FlowReducer<STATE, ACTION, ENVIRONMENT> =
+            FlowReducer { state, action, environment ->
+                // apply all reducers on the state
+                reducers.fold(state + flowNone()) { (state, effect), reducer ->
+                    reducer.reduce(state, action, environment)
+                        // send the final state with the accumulated side-effects
+                        .let { (newState, newEffect) -> newState + (effect + newEffect) }
+                }
+            }
+
+        /**
+         * Combines many reducers into a single one by running each one on the state, and merging
+         * all of the effects.
+         *
+         * @see combine
+         *
+         * @param reducers An array of reducers.
+         * @return A single [FlowReducer].
+         */
+        fun <STATE, ACTION : Any, ENVIRONMENT> combine(
+            vararg reducers: FlowReducer<STATE, ACTION, ENVIRONMENT>
+        ): FlowReducer<STATE, ACTION, ENVIRONMENT> = combine(reducers.toList())
+    }
+}
+
+/**
+ * Helper context to attach extensions to generic types to be used with the reduce function
+ */
+interface FlowReduceContext<STATE, ACTION : Any> {
+
+    /**
+     * Combines a state and an effect into a [FlowReduced] result
+     */
+    fun reduced(state: STATE, effect: FlowEffect<ACTION>): FlowReduced<STATE, ACTION>
+
+    /**
+     * Operator to combine a state and an effect into a [Reduced] result
+     */
+    operator fun STATE.plus(effect: FlowEffect<ACTION>): FlowReduced<STATE, ACTION> =
+        reduced(this, effect)
+
+    /**
+     * Merges effects into a new one
+     */
+    operator fun <ACTION : Any> FlowEffect<ACTION>.plus(effect: FlowEffect<ACTION>): FlowEffect<ACTION> =
+        merge(this, effect)
+
+    companion object {
+
+        /**
+         * [FlowReduceContext] constructor
+         */
+        operator fun <STATE, ACTION : Any> invoke(): FlowReduceContext<STATE, ACTION> =
+            object : FlowReduceContext<STATE, ACTION> {
+                private var reducedHolder: FlowReducedHolder<STATE, ACTION>? = null
+
+                override fun reduced(
+                    state: STATE,
+                    effect: FlowEffect<ACTION>
+                ): FlowReduced<STATE, ACTION> =
+                    reducedHolder
+                        ?.apply { update(state, effect) }
+                        ?: FlowReducedHolder(state, effect)
+                            .also { reducedHolder = it }
+            }
+    }
+}
+
+/**
+ * A function that accepts a State and an Action and produces a new state
+ */
+@Suppress("ParameterListWrapping", "MaxLineLength")
+typealias FlowReduce<STATE, ACTION, ENVIRONMENT> = FlowReduceContext<STATE, ACTION>.(STATE, ACTION, ENVIRONMENT) -> FlowReduced<STATE, ACTION>
+
+interface FlowReduced<out STATE, ACTION : Any> {
+    val state: STATE
+    val effect: FlowEffect<ACTION>
+
+    operator fun component1(): STATE = state
+    operator fun component2(): FlowEffect<ACTION> = effect
+}
+
+internal class FlowReducedHolder<STATE, ACTION : Any>(state: STATE, effect: FlowEffect<ACTION>) :
+    FlowReduced<STATE, ACTION> {
+    override var state: STATE = state
+        private set
+
+    override var effect: FlowEffect<ACTION> = effect
+        private set
+
+    fun update(state: STATE, effect: FlowEffect<ACTION>) {
+        this.state = state
+        this.effect = effect
+    }
+}
+
+/**
+ * Combines a reducers into a single one by running each one on the state, and merging
+ * all of the effects.
+ *
+ * @see combine
+ *
+ * @param reducer Another reducer
+ * @return A single [FlowReducer].
+ */
+fun <STATE, ACTION : Any, ENVIRONMENT> FlowReducer<STATE, ACTION, ENVIRONMENT>.combinedWith(
+    reducer: FlowReducer<STATE, ACTION, ENVIRONMENT>
+): FlowReducer<STATE, ACTION, ENVIRONMENT> = combine(this, reducer)
+
+/**
+ * Transforms a reducer that works on non-optional state into one that works on optional state
+ * by only running the non-optional reducer when state is non-null.
+ */
+inline fun <reified STATE, ACTION : Any, ENVIRONMENT> FlowReducer<STATE, ACTION, ENVIRONMENT>.optional():
+        FlowReducer<STATE?, ACTION, ENVIRONMENT> = FlowReducer { state, action, environment ->
+    state
+        .also {
+            assert(it != null) {
+                """
+                $action was received by an optional reducer when its state was "null".
+                This can happen for a few reasons:
+                * The optional reducer was combined with or run from another reducer that set 
+                  ${STATE::class.java.simpleName} to "null" before the optional reducer ran. 
+                  Combine or run optional reducers before reducers that can set their state to "null". 
+                  This ensures that optional reducers can handle their actions while their state is still non-"null".
+                * An active effect emitted this action while state was "null". Make sure that effects
+                  for this optional reducer are canceled when optional state is set to "null".
+                * This action was sent to the store while state was "null". Make sure that actions
+                  for this reducer can only be sent to a view store when state is non-"null".
+                """
+            }
+        }
+        ?.let { reduce(it, action, environment) }
+        ?: (state + flowNone())
+}

--- a/tka/src/main/kotlin/com/xm/tka/coroutine/StoreScopeProvider.kt
+++ b/tka/src/main/kotlin/com/xm/tka/coroutine/StoreScopeProvider.kt
@@ -1,0 +1,8 @@
+package com.xm.tka.coroutine
+
+import kotlinx.coroutines.CoroutineScope
+
+fun interface StoreScopeProvider {
+    fun getStoreScope(): CoroutineScope
+
+}


### PR DESCRIPTION
- it works fine on my sample app
- created Effect type for kotlin Flow called FlowEffect
- created a Reducer to work with FlowEffect type called FlowReducer
- created Coroutine store
      - used one MutableSateFlow as state holder for the whole store as single source of truth
      - had to abstract the send function off the store instance, because MutableSateFlow can't have parent streams
      - created scop function that takes the parent flow and map it into the local flow
      - removed the synchronization logic, because MutableStateFlow is thread safe
      - removed rx dispose logic, because that's handled automatically by coroutine lifecycle scope
      - abstracted couroutine & dispatchers for testing
- Enhancments we could make:
      - make the reducer return a state change method instead of the actual state, to invoke in the MutableStateFlow::update method, and that will make the state changes fully atomic